### PR TITLE
fix: ensure AI broadcaster check is case insensitive

### DIFF
--- a/api/helpers/event.ts
+++ b/api/helpers/event.ts
@@ -84,7 +84,7 @@ const getTotalFeeDerivedMinutes = ({
  * @returns Boolean indicating if the sender is an AI broadcaster.
  */
 const isAIBroadcaster = (sender: string): boolean => {
-  return AIBroadcasters.broadcasters.some((b) => b.address === sender);
+  return AIBroadcasters.broadcasters.some((b) => b.address.toLowerCase() === sender.toLowerCase());
 };
 
 /**


### PR DESCRIPTION
This pull request ensures that the AI broadcaster check is case insensitive. This ensures that the address is always correctly matched.
