### PR TITLE
fix: deprecate hosted subgraph for decentralised subgraph

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,7 @@ MONGO_PASSWORD=                         # Database password
 MONGO_HOST=cluster0.eutpy.mongodb.net   # Database host
 DISCORD_WEBHOOK_URL=                    # Discord webhook url
 API_TOKEN=                              # Bearer Token for API
+GRAPH_API_KEY=                          # The Graph API Key
 INFURA_KEY=                             # Infura API Key
 NODE_ENV=                               # Environment (development, production)
 TWITTER_CONSUMER_KEY=                   # Twitter API Key

--- a/README.md
+++ b/README.md
@@ -6,12 +6,16 @@ Sends an alert to Discord and Twitter anytime an orchestrator gets paid.
 
 ### Prerequisites
 
+> [!IMPORTANT]\
+> The [hosted Livepeer subgraph](https://thegraph.com/hosted-service/subgraph/livepeer/livepeer) has been deprecated. This bot now utilizes the [Livepeer subgraph](https://thegraph.com/explorer/subgraphs/FE63YgkzcpVocxdCEyEYbvjYqEf2kb1A6daMYRxmejYC?view=Query&chain=arbitrum-one) on The Graph for data retrieval from the Livepeer network. To access this service, you will need an API key and an account with sufficient GRT tokens for queries.
+
 - [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) -
   [NVM](https://github.com/nvm-sh/nvm) is recommended for managing Node
   versions.
 - [Yarn](https://yarnpkg.com/getting-started/install)
 - [MongoDB](https://www.mongodb.com/docs/manual/tutorial/install-mongodb-on-ubuntu/)
 - [Vercel CLI](https://vercel.com/docs/cli)
+- [A Graph API key](https://thegraph.com/docs/developer/quick-start#request-api-key)
 
 ### Local Development
 
@@ -32,6 +36,7 @@ Sends an alert to Discord and Twitter anytime an orchestrator gets paid.
    DISCORD_WEBHOOK_URL=                    # Discord webhook url
    API_TOKEN=                              # Bearer Token for API
    INFURA_KEY=                             # Infura API Key
+   GRAPH_API_KEY=                          # The Graph API Key
    NODE_ENV=development                    # Environment (development, production)
    ```
 

--- a/api/update.ts
+++ b/api/update.ts
@@ -60,7 +60,7 @@ export default async (req: VercelRequest, res: VercelResponse) => {
 
   // Retrieve the latest winning ticket redeemed events.
   const { winningTicketRedeemedEvents } = await request(
-    "https://api.thegraph.com/subgraphs/name/livepeer/arbitrum-one",
+    `https://gateway-arbitrum.network.thegraph.com/api/${process.env.GRAPH_API_KEY}/subgraphs/id/FE63YgkzcpVocxdCEyEYbvjYqEf2kb1A6daMYRxmejYC`,
     WINNING_TICKET_QUERY
   );
 


### PR DESCRIPTION
This pull request ensures that the now deprecated [hosted Livepeer subgraph](https://thegraph.com/hosted-service/subgraph/livepeer/livepeer) is replaced by its [decentralised counterpart](https://thegraph.com/explorer/subgraphs/FE63YgkzcpVocxdCEyEYbvjYqEf2kb1A6daMYRxmejYC?view=Query&chain=arbitrum-one).
